### PR TITLE
Android security 11.0.0 release 66

### DIFF
--- a/libs/gui/LayerState.cpp
+++ b/libs/gui/LayerState.cpp
@@ -276,6 +276,27 @@ void DisplayState::merge(const DisplayState& other) {
     }
 }
 
+void DisplayState::sanitize(bool privileged) {
+    if (what & DisplayState::eLayerStackChanged) {
+        if (!privileged) {
+            what &= ~DisplayState::eLayerStackChanged;
+            ALOGE("Stripped attempt to set eLayerStackChanged in sanitize");
+        }
+    }
+    if (what & DisplayState::eDisplayProjectionChanged) {
+        if (!privileged) {
+            what &= ~DisplayState::eDisplayProjectionChanged;
+            ALOGE("Stripped attempt to set eDisplayProjectionChanged in sanitize");
+        }
+    }
+    if (what & DisplayState::eSurfaceChanged) {
+        if (!privileged) {
+            what &= ~DisplayState::eSurfaceChanged;
+            ALOGE("Stripped attempt to set eSurfaceChanged in sanitize");
+        }
+    }
+}
+
 void layer_state_t::merge(const layer_state_t& other) {
     if (other.what & ePositionChanged) {
         what |= ePositionChanged;

--- a/libs/gui/include/gui/LayerState.h
+++ b/libs/gui/include/gui/LayerState.h
@@ -267,6 +267,7 @@ struct DisplayState {
 
     DisplayState();
     void merge(const DisplayState& other);
+    void sanitize(bool privileged);
 
     uint32_t what;
     sp<IBinder> token;

--- a/services/surfaceflinger/SurfaceFlinger.cpp
+++ b/services/surfaceflinger/SurfaceFlinger.cpp
@@ -3319,7 +3319,7 @@ bool SurfaceFlinger::flushTransactionQueues() {
             auto& [applyToken, transactionQueue] = *it;
 
             while (!transactionQueue.empty()) {
-                const auto& transaction = transactionQueue.front();
+                auto& transaction = transactionQueue.front();
                 if (!transactionIsReadyToBeApplied(transaction.desiredPresentTime,
                                                    transaction.states)) {
                     setTransactionFlags(eTransactionFlushNeeded);
@@ -3418,13 +3418,18 @@ void SurfaceFlinger::setTransactionState(
         return;
     }
 
-    applyTransactionState(states, displays, flags, inputWindowCommands, desiredPresentTime,
+    Vector<DisplayState> displaysList;
+    for (auto& d : displays) {
+        displaysList.add(d);
+    }
+
+    applyTransactionState(states, displaysList, flags, inputWindowCommands, desiredPresentTime,
                           uncacheBuffer, postTime, privileged, hasListenerCallbacks,
                           listenerCallbacks);
 }
 
 void SurfaceFlinger::applyTransactionState(
-        const Vector<ComposerState>& states, const Vector<DisplayState>& displays, uint32_t flags,
+        const Vector<ComposerState>& states, Vector<DisplayState>& displays, uint32_t flags,
         const InputWindowCommands& inputWindowCommands, const int64_t desiredPresentTime,
         const client_cache_t& uncacheBuffer, const int64_t postTime, bool privileged,
         bool hasListenerCallbacks, const std::vector<ListenerCallbacks>& listenerCallbacks,
@@ -3447,7 +3452,8 @@ void SurfaceFlinger::applyTransactionState(
         }
     }
 
-    for (const DisplayState& display : displays) {
+    for (DisplayState& display : displays) {
+        display.sanitize(privileged);
         transactionFlags |= setDisplayStateLocked(display);
     }
 

--- a/services/surfaceflinger/SurfaceFlinger.h
+++ b/services/surfaceflinger/SurfaceFlinger.h
@@ -618,9 +618,8 @@ private:
     /* ------------------------------------------------------------------------
      * Transactions
      */
-    void applyTransactionState(const Vector<ComposerState>& state,
-                               const Vector<DisplayState>& displays, uint32_t flags,
-                               const InputWindowCommands& inputWindowCommands,
+    void applyTransactionState(const Vector<ComposerState>& state, Vector<DisplayState>& displays,
+                               uint32_t flags, const InputWindowCommands& inputWindowCommands,
                                const int64_t desiredPresentTime,
                                const client_cache_t& uncacheBuffer, const int64_t postTime,
                                bool privileged, bool hasListenerCallbacks,


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r66' of https://android.googlesource.com/platform/frameworks/native into arrow-11.0

Android security 11.0.0 release 66
Tag: https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-security-11.0.0_r66

Merge cherrypicks of ['googleplex-android-review.googlesource.com/20892111'] into security-aosp-rvc-release.

Change-Id: [Iaaa563f48347c21dfb87dbc886294e6951122f12](https://android-review.googlesource.com/#/q/Iaaa563f48347c21dfb87dbc886294e6951122f12)