### PR TITLE
Android security 11.0.0 release 72

### DIFF
--- a/libs/sensor/SensorManager.cpp
+++ b/libs/sensor/SensorManager.cpp
@@ -172,11 +172,8 @@ status_t SensorManager::assertStateLocked() {
 
         mSensors = mSensorServer->getSensorList(mOpPackageName);
         size_t count = mSensors.size();
-        if (count == 0) {
-            ALOGE("Failed to get Sensor list");
-            mSensorServer.clear();
-            return UNKNOWN_ERROR;
-        }
+        // If count is 0, mSensorList will be non-null. This is old
+        // existing behavior and callers expect this.
         mSensorList =
                 static_cast<Sensor const**>(malloc(count * sizeof(Sensor*)));
         LOG_ALWAYS_FATAL_IF(mSensorList == nullptr, "mSensorList NULL");


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r72' of https://android.googlesource.com/platform/frameworks/native into arrow-11.0

Android security 11.0.0 release 72
Tag: https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-security-11.0.0_r72

Merge cherrypicks of ['googleplex-android-review.googlesource.com/23677151'] into security-aosp-rvc-release.

Change-Id: [I9353d96be061757b7ba60535e8b14dace8424422](https://android-review.googlesource.com/#/q/I9353d96be061757b7ba60535e8b14dace8424422)